### PR TITLE
Add REPL support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "webpack --env dev && webpack --env build && npm run test",
     "dev": "webpack --progress --colors --watch --env dev",
     "test": "mocha --require babel-register --colors ./test/*.spec.js",
-    "test:watch": "mocha --require babel-register --colors -w ./test/*.spec.js"
+    "test:watch": "mocha --require babel-register --colors -w ./test/*.spec.js",
+    "repl": "node -i -e \"$(< ./lib/webpack-library-starter.js)\""
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,8 @@ const config = {
     filename: outputFile,
     library: libraryName,
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: "typeof self !== 'undefined' ? self : this"
   },
   module: {
     rules: [


### PR DESCRIPTION
This PR allows to open a repl by running `yarn repl` with the build file loaded. 

For reference the weird line on webpack is due to a known issue. Using the repl command without that change results in `window is not defined` error.
See https://github.com/webpack/webpack/issues/6522.